### PR TITLE
Upgrade Nginx to 1.14.0 and introduce psol version support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,9 +16,10 @@ nginx_build_options:
   with-ipv6:
   with-pcre-jit:
 
-nginx_pagespeed_version: 1.12.34.2
+nginx_pagespeed_version: 1.12.34.3
 nginx_pagespeed_version_label: stable
+nginx_psol_version: 1.12.34.2
 nginx_user: www-data
-nginx_version: 1.10.1
+nginx_version: 1.14.0
 nginx_worker_processes: 2
 nginx_pagespeed_enabled: false

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -16,7 +16,7 @@ nginx_build_options_defaults:
   prefix: "{{ nginx_prefix }}"
 
 
-nginx_psol_url: https://dl.google.com/dl/page-speed/psol/{{ nginx_pagespeed_version }}-x64.tar.gz
+nginx_psol_url: https://dl.google.com/dl/page-speed/psol/{{ nginx_psol_version | default(nginx_pagespeed_version) }}-x64.tar.gz
 nginx_pagespeed_url: https://github.com/apache/incubator-pagespeed-ngx/archive/v{{ nginx_pagespeed_version }}-{{ nginx_pagespeed_version_label }}.zip
 nginx_url: http://nginx.org/download/nginx-{{ nginx_version }}.tar.gz
 


### PR DESCRIPTION
It seems that not every Pagespeed version has its own Pagespeed Library version.
So introduce `nginx_psol_version` to retrive `nginx_psol_url` from it, when it's defined - otherwise default to `nginx_pagespeed_version`.

Update nginx to last stable version, i.e. 1.14.0.
Update Pagespeed to version 1.12.34.3 - [which solves the building bug](https://www.modpagespeed.com/doc/release_notes#release_1.12.34.3-stable)  
Use psol v. 1.12.34.2 - because version 1.12.34.3 doesn't exist